### PR TITLE
added npm ls for package checking BACKEND-867

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "rm -Rf dst && tsc && cd src && find . -name '*.json' -type f -exec cp {} ../dst/{} \\; && cd ..",
-    "pack-local": "rm -f dst.zip && cp package.json dst/package.json && (cp .npmrc dst/.npmrc || true) && cd dst && ln -s ../node_modules node_modules && zip -r ../dst.zip . ** && cd ..",
-    "pack": "rm -f dst.zip && cp package.json dst/package.json && (cp .npmrc dst/.npmrc || true) && cd dst && npm install --cache=../.npm --production && zip -r ../dst.zip . ** && cd ..",
+    "pack-local": "rm -f dst.zip && cp package.json dst/package.json && (cp .npmrc dst/.npmrc || true) && cd dst && ln -s ../node_modules node_modules && npm ls && zip -r ../dst.zip . ** && cd ..",
+    "pack": "rm -f dst.zip && cp package.json dst/package.json && (cp .npmrc dst/.npmrc || true) && cd dst && npm install --cache=../.npm --production && npm ls && zip -r ../dst.zip . ** && cd ..",
     "dynamodb:cleanup": "(test -e $TMPDIR/dynamodb-local.pid && pkill -SIGINT -P $(cat $TMPDIR/dynamodb-local.pid)); rm -f $TMPDIR/dynamodb-local.pid",
     "dynamodb:setup": "node $(npm bin)/local-dynamo --port 8000 & echo $! > $TMPDIR/dynamodb-local.pid; sleep 3",
     "pretest": "rm -Rf dst && tsc -p ./tsconfig.test.json && cd src && find . -name '*.json' -type f -exec cp {} ../dst/{} \\; && cd .. && npm run dynamodb:cleanup && npm run dynamodb:setup",


### PR DESCRIPTION
Currently CI / CD process won't fail even if there is unmet peer dependency. 
`npm ls` checks this, and fails if there is unmet peer dependencies.
 