### PR TITLE
BACKEND-1311 Update default lambda runtime to nodejs8.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,9 @@
-FROM node:6.5.0
+FROM node:8.10.0
 
 MAINTAINER Kurt Lee "kurt@vingle.net"
 
 # Install system programs
 RUN apt-get update && apt-get install -y zip build-essential curl openjdk-7-jdk memcached jq && apt-get clean
-
-# # Install npm 5 in order to use package-lock.json
-# RUN curl -L https://npmjs.org/install.sh | sh
-RUN cd $(npm root -g)/npm && \
-    npm install fs-extra && \
-    sed -i -e s/graceful-fs/fs-extra/ -e s/fs.rename/fs.move/ ./lib/utils/rename.js
-RUN npm install -g npm@5.6.0
 
 # Configure JAVA HOME
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,8 @@ node(label: 'Small') {
     step([$class: 'GitHubSetCommitStatusBuilder'])
 
     withDockerRegistry(registry: [credentialsId: 'docker-hub', url: 'https://index.docker.io/v1/']) {
-      docker.image('vingle/lambda-microservice-template').pull()
-      withDockerContainer([image: 'vingle/lambda-microservice-template']) {
+      docker.image('vingle/lambda-microservice-template:8.10').pull()
+      withDockerContainer([image: 'vingle/lambda-microservice-template:8.10']) {
         stage('Checkout SCM') {
           checkout scm
         }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "info:prod": "sls info -s prod"
   },
   "engines": {
-    "node": "6.10.*",
+    "node": "8.10.*",
     "npm": "^5.6.0"
   },
   "author": "Kurt Lee",

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: microservice-template
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
   stage: prod
 
 package:

--- a/src/handlers/handler_wrapper.ts
+++ b/src/handlers/handler_wrapper.ts
@@ -3,20 +3,14 @@ import * as Base from "../interfaces/base";
 export default class HandlerWrapper {
   // tslint:disable-next-line
   static safelyWrap(handler: Function) {
-    return (event: Base.Event, context: Base.Context<Base.Response>) => {
-      const result = handler(event, context);
-      const isPromise = Promise.resolve(result) === result;
+    return (event: Base.Event, context: Base.Context<Base.Response>, callback: any) => {
+      context.callbackWaitsForEmptyEventLoop = false;
 
-      if (isPromise) {
-        const promise = result as Promise<Base.Response>;
-        promise.then(
-          (response) => {
-            context.done(null, response);
-          }, (error) => {
-            context.done(error);
-          },
-        );
-      }
+      const result = handler(event, context);
+
+      Promise.resolve(result)
+        .then((response) => callback(null, response))
+        .catch((error) => callback(error));
     };
   }
 }

--- a/src/interfaces/base.ts
+++ b/src/interfaces/base.ts
@@ -26,6 +26,7 @@ export interface Context<T> {
     logStreamName: string;
     identity?: CognitoIdentity;
     clientContext?: ClientContext;
+    callbackWaitsForEmptyEventLoop?: boolean;
 
     // Functions
     succeed(result?: T): void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2017",
         "noImplicitAny": true,
         "sourceMap": true,
         "outDir": "dst",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2017",
         "noImplicitAny": true,
         "sourceMap": true,
         "outDir": "dst",


### PR DESCRIPTION
Lambda Runtime을 Node.js 8.10으로 업데이트합니다.

Docker container가 아직 만들어지지 않은 상태라 머지 후 아래 작업을 처리해야합니다:

(master merge 후 Docker Hub에서 새 이미지 빌드가 돌아가서, latest tag가 변경됩니다)
1. 새로 만든 이미지를 `vingle/lambda-microservice-template:8.10` 으로 태깅합니다
2. 이전 nodejs6.10 프로젝트들에 대해 영향을 주지 않기 위해 docker image의 latest tag를 이전 6.10 이미지의 ID로 되돌립니다.
